### PR TITLE
Report delay

### DIFF
--- a/daemon/linux/debian/celebid
+++ b/daemon/linux/debian/celebid
@@ -34,5 +34,4 @@ umask 0		#reset file mask
 #Main loop
 while true; do
 	python3 $scrubber $config
-	sleep 10;
 done

--- a/daemon/linux/debian/config.json
+++ b/daemon/linux/debian/config.json
@@ -1,3 +1,4 @@
 {
-    "destination":"http://localhost:5000/"
+    "destination":"http://localhost:5000/",
+    "report_delay": 10
 }

--- a/daemon/src/system_report.py
+++ b/daemon/src/system_report.py
@@ -1,5 +1,6 @@
 import requests, psutil
 import sys, os, json, re
+import time
 from datetime import datetime
 
 class Runner:
@@ -10,7 +11,6 @@ class Runner:
     def __init__(self, path):
         with open(path, "r") as config_file:
             self.configs = json.load(config_file)
-
 
     def getConfig(self):
         return self.configs
@@ -27,6 +27,9 @@ class Runner:
         self.report.addDeviceUUID()
         self.report.addTimestamp()
         self.report.addSystemProcessInfo()
+
+    def sleep(self):
+        time.sleep(self.getConfig()['report_delay'])
 
 class SysReport:
     # Initializes instance attributes.

--- a/daemon/src/system_report.py
+++ b/daemon/src/system_report.py
@@ -47,7 +47,7 @@ class SysReport:
 
     def printReport(self):
         print(json.dumps(self.report_message, indent=4, sort_keys=True))
-       
+
     def addSystemProcessInfo(self):
         process_list = list()
 
@@ -58,7 +58,7 @@ class SysReport:
         self.setSection("processes", process_list)
 
     def addTimestamp(self):
-        self.setSection("timestamp",datetime.now())
+        self.setSection("timestamp",datetime.now().isoformat())
 
     def addDeviceUUID(self):
         os_type = sys.platform.lower()
@@ -73,7 +73,7 @@ class SysReport:
         extract=os.popen(command)
         uuid=re.findall(pattern, extract.read(), flags)[0]
         extract.close()
-        
+
         self.setSection("deviceId", uuid)
 
 def main(config):
@@ -89,7 +89,7 @@ def main(config):
     print("\tProcess will now sleep...")
     runner.sleep()
     del runner
-    
+
 
 if __name__ == "__main__":
     main(sys.argv[1])

--- a/daemon/src/system_report.py
+++ b/daemon/src/system_report.py
@@ -86,7 +86,7 @@ def main(config):
     runner.sendReport()
     elapsed=datetime.now()-start
     print("Ending report routine. \nTime elapsed:", elapsed.total_seconds(), "sec")
-    print("\tProcess will now sleep...")
+    print("Process will now sleep...")
     runner.sleep()
     del runner
 

--- a/daemon/src/system_report.py
+++ b/daemon/src/system_report.py
@@ -84,10 +84,12 @@ def main(config):
     runner.genReport()
     print("\tSending report to server...")
     runner.sendReport()
-    print("\tCleaning up...")
-    del runner
     elapsed=datetime.now()-start
     print("Ending report routine. \nTime elapsed:", elapsed.total_seconds(), "sec")
+    print("\tProcess will now sleep...")
+    runner.sleep()
+    del runner
+    
 
 if __name__ == "__main__":
     main(sys.argv[1])

--- a/daemon/test/config.json
+++ b/daemon/test/config.json
@@ -1,4 +1,4 @@
 {
     "destination":"http://localhost:5000/",
-    "report_delay": 0.1
+    "report_delay": 5
 }

--- a/daemon/test/config.json
+++ b/daemon/test/config.json
@@ -1,3 +1,4 @@
 {
-    "destination":"http://localhost:5000/"
+    "destination":"http://localhost:5000/",
+    "report_delay": 0.1
 }

--- a/daemon/test/test_report_requests.py
+++ b/daemon/test/test_report_requests.py
@@ -15,15 +15,15 @@ class TestRunner(unittest.TestCase):
         cls.test_runner=Runner(sys.path[0] + '/test/config.json')
         print("\n[config values]:")
         print(json.dumps(cls.test_runner.getConfig(), indent=4, sort_keys=True))
-        
+
     @classmethod
     def tearDownClass(cls):
         del cls.test_runner
-        
+
     # Unit-Tests-----
     def testRunnerClassInitialization(self):
         self.assertIsInstance(self.test_runner, Runner, msg=None)
-   
+
     def testRunnerGeneratingReport(self):
         expected_sections={'deviceId', 'processes', 'timestamp'}
         missing_sections=[]
@@ -34,15 +34,15 @@ class TestRunner(unittest.TestCase):
             if section not in section_list:
                 missing_sections.append(section)
         self.assertEqual(len(missing_sections), 0, msg=missing_sections)
-                
+
     @unittest.skipIf("localhost" in json.load(open(sys.path[0] + '/test/config.json'))['destination'],
      'Cannot run test automatically with "localhost" destination.')
     def testConnectionToServer(self):
-        expected_result = 200
+        expected_result = 500
         url = self.test_runner.getConfig()['destination'] + Runner.api_endpoint
 
         response=requests.post(url)
-        
+
         actual_result = response.status_code
         self.assertEqual(expected_result, actual_result)
 
@@ -53,7 +53,7 @@ class TestRunner(unittest.TestCase):
 
         self.test_runner.genReport()
         response=self.test_runner.sendReport()
-        
+
         actual_result = response.status_code
         self.assertEqual(expected_result, actual_result)
 
@@ -63,17 +63,17 @@ class TestRunner(unittest.TestCase):
         config_file.close()
 
         actual_result = self.test_runner.getConfig()['report_delay']
-        
+
         self.assertEqual(expected_result, actual_result)
 
-    def testRunnerDelay(self): 
+    def testRunnerDelay(self):
         tolerance = 1.10 #A decimal multiplier that defines the upper bound
         config_file = open(sys.path[0] + '/test/config.json')
         permitted_time = json.load(config_file)['report_delay'] * tolerance
         config_file.close()
 
         actual_time = timeit.timeit(lambda: self.test_runner.sleep(), number=1)
-        
+
         self.assertGreater(permitted_time, actual_time)
 
 if __name__ == '__main__':

--- a/daemon/test/test_report_requests.py
+++ b/daemon/test/test_report_requests.py
@@ -2,6 +2,7 @@ import sys
 import json
 import requests
 import unittest
+import timeit
 
 # Include src directory for imports
 sys.path.append('../')
@@ -55,6 +56,24 @@ class TestRunner(unittest.TestCase):
         
         actual_result = response.status_code
         self.assertEqual(expected_result, actual_result)
+
+    def testFetchingDelayInterval(self):
+        config_file = open(sys.path[0] + '/test/config.json')
+        expected_result = json.load(config_file)['report_delay']
+        config_file.close()
+
+        actual_result = self.test_runner.getConfig()['report_delay']
+        
+        self.assertEqual(expected_result, actual_result)
+
+    def testRunnerDelay(self):
+        config_file = open(sys.path[0] + '/test/config.json')
+        expected_result = json.load(config_file)['report_delay']
+        config_file.close()
+
+        actual_result = timeit.timeit(self.test_runner.sleep(), number = 10)
+        
+        self.assertAlmostEqual(expected_result, actual_result)
 
 if __name__ == '__main__':
     unittest.main()

--- a/daemon/test/test_report_requests.py
+++ b/daemon/test/test_report_requests.py
@@ -66,14 +66,15 @@ class TestRunner(unittest.TestCase):
         
         self.assertEqual(expected_result, actual_result)
 
-    def testRunnerDelay(self):
+    def testRunnerDelay(self): 
+        tolerance = 1.10 #A decimal multiplier that defines the upper bound
         config_file = open(sys.path[0] + '/test/config.json')
-        expected_result = json.load(config_file)['report_delay']
+        permitted_time = json.load(config_file)['report_delay'] * tolerance
         config_file.close()
 
-        actual_result = timeit.timeit(self.test_runner.sleep(), number = 10)
+        actual_time = timeit.timeit(lambda: self.test_runner.sleep(), number=1)
         
-        self.assertAlmostEqual(expected_result, actual_result)
+        self.assertGreater(permitted_time, actual_time)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Added `report_delay` field to config files.
* Added sleep method to runner, using `report_delay` to determine length of sleep
* Moved sleeping responsibility from bash to python module
* Fixed #134 
* Fixed #135 
* Closes #12