### PR TITLE
Fix Change Stream Flaky Test

### DIFF
--- a/server/__tests__/change_streams.test.js
+++ b/server/__tests__/change_streams.test.js
@@ -79,7 +79,7 @@ describe('Insert a new user to the database and get data from the change stream'
     } catch (err) {
       expect(err).toBeFalsy()
     }
-  })
+  }, 15000)
 
   afterAll(() => {
     if (testValues.wsClient) {

--- a/server/__tests__/change_streams.test.js
+++ b/server/__tests__/change_streams.test.js
@@ -45,8 +45,12 @@ beforeAll(async () => {
 })
 
 describe('Insert a new user to the database and get data from the change stream', () => {
-  beforeAll(() => {
+  beforeAll(async () => {
     monitorCollection(collectionName)
+    await new Promise((resolve) => {
+      while (numOfMonitoredChangeStream() === 0);
+      resolve()
+    })
   })
 
   it('should receive the inserted data from the websocket', async () => {

--- a/server/db/change_streams.js
+++ b/server/db/change_streams.js
@@ -46,8 +46,8 @@ const attachNotifyClients = (changeStream) => {
  */
 const monitorCollection = (collectionName) => {
   const changeStream = createChangeStream(collectionName)
-  changeStreamsMonitored.push(changeStream)
   attachNotifyClients(changeStream)
+  changeStreamsMonitored.push(changeStream)
 }
 
 /**


### PR DESCRIPTION
* Server Tests - Extend Timeout For Change Stream Test
Change stream test now has a 15 second timeout instead of 5 seconds.
* Server Test - Require Change Stream Connection Established Before Test Starts
Wait for the change stream to be monitored before starting the test

closes #141 
