### PR TITLE
Client - Notification service

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4226,6 +4226,11 @@
         }
       }
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -13866,6 +13871,14 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
         }
+      }
+    },
+    "react-toastify": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-8.1.0.tgz",
+      "integrity": "sha512-M+Q3rTmEw/53Csr7NsV/YnldJe4c7uERcY7Tma9mvLU98QT2VhIkKwjBzzxZkJRk/oBKyUAtkyMjMgO00hx6gQ==",
+      "requires": {
+        "clsx": "^1.1.1"
       }
     },
     "react-transition-group": {

--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
     "react-icons": "^4.3.1",
     "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3",
+    "react-toastify": "^8.1.0",
     "typescript": "^4.4.3",
     "web-vitals": "^1.1.2"
   },

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -1,3 +1,5 @@
+@import 'react-toastify/dist/ReactToastify.css';
+
 html, body, #root, #root>div {
   height: 100%;
   margin: 0;

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -11,7 +11,7 @@ ReactDOM.render(
       <AuthProvider>
         <App />
       </AuthProvider>
-      <ToastContainer bodyClassName="h-0" />
+      <ToastContainer />
     </div>,
     document.getElementById('root'),
 );

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -4,11 +4,15 @@ import './index.scss';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import {AuthProvider} from './context/authContext';
+import {ToastContainer} from 'react-toastify';
 
 ReactDOM.render(
-    <AuthProvider>
-      <App />
-    </AuthProvider>,
+    <div className="app">
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+      <ToastContainer bodyClassName="h-0" />
+    </div>,
     document.getElementById('root'),
 );
 

--- a/client/src/services/notification.service.tsx
+++ b/client/src/services/notification.service.tsx
@@ -1,0 +1,30 @@
+import {toast, ToastOptions, Bounce} from 'react-toastify';
+
+const toastifyOptions: ToastOptions<{}> = {
+  position: 'bottom-right',
+  autoClose: 3000,
+  theme: 'colored',
+  transition: Bounce,
+  hideProgressBar: false,
+  closeOnClick: true,
+  pauseOnHover: true,
+  pauseOnFocusLoss: false,
+  draggable: false,
+  progress: undefined,
+};
+
+export const notificationService = {
+  info: (message: string) => {
+    toast.info(message, toastifyOptions);
+  },
+  success: (message: string) => {
+    toast.success(message, toastifyOptions);
+  },
+  warning: (message: string) => {
+    toast.warning(message, toastifyOptions);
+  },
+  error: (message: string) => {
+    toast.error(message, toastifyOptions);
+  },
+
+};


### PR DESCRIPTION
- Client - Install React Toastify Library 
Adds React-Toastify library for notifications to the client application
- Client - Adds Notification Service 
Use notification to use react-toastify

To use the notification service:
1. `import {notificationService} from '../services/notification.service';`
2. use `notificationService.info('message to display');`
notification service comes for 'info', 'success', 'warning', and 'error'.

Examples:
![image](https://user-images.githubusercontent.com/47483376/142336364-b8282423-051c-42dc-bd25-429f99b2471a.png)
![image](https://user-images.githubusercontent.com/47483376/142336403-96eb31e5-f525-4c42-a7b1-f6ad7fe5fa1a.png)

Links Issue #32 