### PR TITLE
bug fix - auth provider on redirects and links

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable require-jsdoc */
 import React from 'react';
 import './App.scss';
-import {BrowserRouter as Router, Route} from 'react-router-dom';
+import {Route} from 'react-router-dom';
 import PrivateRoute from './routes/privateRoute';
 import Login from './components/login';
 import Dashboard from './components/dashboard';
@@ -9,10 +9,11 @@ import AdminPanel from './components/adminPanel';
 import Signup from './components/signup';
 import DevicePage from './components/devicePage';
 import deviceDetailPage from './components/deviceDetailPage';
+import {AuthProvider} from './context/authContext';
 
 function App() {
   return (
-    <Router>
+    <AuthProvider>
       <Route exact path="/" component={Login}></Route>
       <Route exact path="/signup" component={Signup}></Route>
       <PrivateRoute
@@ -39,7 +40,7 @@ function App() {
         roles={['admin']}
         component={AdminPanel}
       ></PrivateRoute>
-    </Router>
+    </AuthProvider>
   );
 }
 

--- a/client/src/context/authContext.tsx
+++ b/client/src/context/authContext.tsx
@@ -1,5 +1,6 @@
 import React, {createContext, useState, useEffect, useContext} from 'react';
 import AuthService from '../services/authService';
+import {useLocation} from 'react-router-dom';
 
 interface AuthObject {
   isAuthenticated: boolean
@@ -29,16 +30,18 @@ export function useAuth() {
  * @return {void} auth context values
  */
 export function AuthProvider({children}: any) {
+  const location = useLocation();
   const [user, setUser] = useState({name: '', role: ''});
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [loading, setLoading] = useState(true);
+  // check authentication of user on router dom changes(for links and redirects) and initial page loads
   useEffect(() => {
     AuthService.isAuthenticated().then((data: any) => {
       setUser(data.user);
       setIsAuthenticated(data.isAuthenticated);
       setLoading(false);
     });
-  }, []);
+  }, [location]);
 
   const authContextValue = {
     user,

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.scss';
 import App from './App';
+import {BrowserRouter as Router} from 'react-router-dom';
 import reportWebVitals from './reportWebVitals';
-import {AuthProvider} from './context/authContext';
 import {ToastContainer} from 'react-toastify';
 
 ReactDOM.render(
     <div className="app">
-      <AuthProvider>
+      <Router>
         <App />
-      </AuthProvider>
+      </Router>
       <ToastContainer />
     </div>,
     document.getElementById('root'),


### PR DESCRIPTION
The authContext useEffect would not trigger AuthService.isAuthenticated() on redirect or link due to the application not re-rendering.
By using useLocation from browser router in the authContext useffect, it will now trigger AuthService.isAuthenticated() accordingly when a user uses a link or a redirect.

Fixes bug #128