### PR TITLE
Api query total

### DIFF
--- a/server/__tests__/api/device.test.js
+++ b/server/__tests__/api/device.test.js
@@ -72,7 +72,7 @@ describe('Retrieve a specific device given name or id', () => {
   it('should retreive the total number of devices in the database with a limit', async () => {
     const response = await request(app)
       .get('/api/device')
-      .query({ Total: true, lmit: 1 })
+      .query({ Total: true, limit: 1 })
       .set('Cookie', cookieSession)
 
     const total = response.body.Total

--- a/server/__tests__/api/device_logs.test.js
+++ b/server/__tests__/api/device_logs.test.js
@@ -149,6 +149,20 @@ describe('Get the latest logs from the devices', () => {
     expect(results.length).toBe(0)
   })
 
+  it('should retrieve an empty array if no Ids are passed', async () => {
+    const query = {
+      Ids: [''],
+    }
+
+    const response = await request(app)
+      .get('/api/device-logs/latest')
+      .query(query)
+      .set('Cookie', cookieSession)
+
+    expect(response.statusCode).toBe(200)
+    expect(response.body.Results.length).toBe(0)
+  })
+
   it('should throw an error if no "Ids" attribute is passed in the query', async () => {
     const query = {
       invalid: true,

--- a/server/__tests__/api/device_logs.test.js
+++ b/server/__tests__/api/device_logs.test.js
@@ -92,6 +92,24 @@ describe('Get Device Logs from attributes', () => {
     expect(results[0].deviceId).toBe(payloadDeviceId)
     expect(results[1].deviceId).toBe(payloadDeviceId)
   })
+
+  it('should retreive the total number of DeviceLogs in the database with a limit', async () => {
+    const payloadDeviceId = mockLogPayload1.deviceId
+    const query = {
+      deviceId: payloadDeviceId,
+      Total: true,
+      lmit: 1,
+    }
+
+    const response = await request(app)
+      .get('/api/device-logs')
+      .query(query)
+      .set('Cookie', cookieSession)
+
+    const total = response.body.Total
+    expect(response.statusCode).toBe(200)
+    expect(total).toBe(2)
+  })
 })
 
 describe('Get the latest logs from the devices', () => {

--- a/server/__tests__/api/device_logs.test.js
+++ b/server/__tests__/api/device_logs.test.js
@@ -98,7 +98,7 @@ describe('Get Device Logs from attributes', () => {
     const query = {
       deviceId: payloadDeviceId,
       Total: true,
-      lmit: 1,
+      limit: 1,
     }
 
     const response = await request(app)

--- a/server/api/cpuLogs.js
+++ b/server/api/cpuLogs.js
@@ -20,7 +20,11 @@ router.get('/', auth, async (req, res) => {
     CpuProjection,
     options
   )
-  return res.status(200).json({ Results: results })
+  const cpuResponse = { Results: results }
+  if (req.query.Total) {
+    cpuResponse.Total = await DeviceLogs.countDocuments(query)
+  }
+  return res.status(200).json(cpuResponse)
 })
 
 module.exports = router

--- a/server/api/device.js
+++ b/server/api/device.js
@@ -9,14 +9,22 @@ const { parseQuery } = require('./common/filter')
 router.get('/ids', auth, async (req, res) => {
   const [query, options] = parseQuery(Object(req.query), DeviceSchema)
   const devices = await Devices.find(query, { deviceId: 1 }, options)
-  return res.status(200).json({ Results: devices.map((d) => d.deviceId) })
+  const deviceIdsResponse = { Results: devices.map((d) => d.deviceId) }
+  if (req.query.Total) {
+    deviceIdsResponse.Total = await Devices.countDocuments(query)
+  }
+  return res.status(200).json(deviceIdsResponse)
 })
 
 // get multiple devices with param options (limit, multiple attributes, orderBy, orderValue)
 router.get('/', auth, async (req, res) => {
   const [query, options] = parseQuery(Object(req.query), DeviceSchema)
   const results = await Devices.find({ $and: [query] }, {}, options)
-  return res.status(200).json({ Results: results })
+  const deviceResponse = { Results: results }
+  if (req.query.Total) {
+    deviceResponse.Total = await Devices.countDocuments(query)
+  }
+  return res.status(200).json(deviceResponse)
 })
 
 module.exports = router

--- a/server/api/deviceLogs.js
+++ b/server/api/deviceLogs.js
@@ -8,7 +8,11 @@ const { DeviceLogs, DeviceLogsSchema } = require('../models/device_logs.js')
 router.get('/', auth, async (req, res) => {
   const [query, options] = parseQuery(Object(req.query), DeviceLogsSchema)
   const results = await DeviceLogs.find({ $and: [query] }, {}, options)
-  return res.status(200).json({ Results: results })
+  const deviceLogsResponse = { Results: results }
+  if (req.query.Total) {
+    deviceLogsResponse.Total = await DeviceLogs.countDocuments(query)
+  }
+  return res.status(200).json(deviceLogsResponse)
 })
 
 // get latest device logs from a list of device Ids

--- a/server/api/deviceLogs.js
+++ b/server/api/deviceLogs.js
@@ -21,7 +21,11 @@ router.get('/latest', auth, async (req, res) => {
 
   // If query does not have Ids attribute
   if (!query.Ids) {
-    return res.status(501).send('Server Error: must include Ids parameter')
+    if (query.Ids === undefined) {
+      return res.status(501).send('Server Error: must include Ids parameter')
+    } else {
+      return res.status(200).json({ Results: [] })
+    }
   }
 
   const idsArray = String(query.Ids).split(',')


### PR DESCRIPTION
When querying the API, can include the "Total" keyword and it will return the total number of entries that match the query, not limited by the "limit" keyword. Useful for tables.
---
* Server - API Queries Also Returns Total 
Total is the number of entries in the collection that match the query not including the limit
* Server Test - Adds Tests For Getting API Totals
* Server - Latest Device Logs Returns Empty Array Instead of Error 
Return empty array instead of error when "Ids" parameter is provided but empty
* Server Test - Add Tests For Latest Device Logs

Relates #155